### PR TITLE
dlopen sourcekitd binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,10 @@ CC := clang
 CFLAGS ?= -Weverything -I.
 
 ifeq ($(shell uname),Darwin)
-XCODE_PATH ?= $(shell xcode-select -p)
-SOURCEKIT_DIRECTORY ?= $(XCODE_PATH)/Toolchains/XcodeDefault.xctoolchain/usr/lib/
-CFLAGS += -F$(SOURCEKIT_DIRECTORY)
-LDFLAGS ?= -Wl,-rpath,$(SOURCEKIT_DIRECTORY) -framework sourcekitd
+LDFLAGS ?=
 else
-SOURCEKIT_DIRECTORY ?= /usr/lib
-LDFLAGS ?= -Wl,-rpath,$(SOURCEKIT_DIRECTORY),-rpath,/usr/lib/swift/linux,-PIC \
-		   -L$(SOURCEKIT_DIRECTORY) -L/usr/lib/swift/linux \
-		   -l sourcekitdInProc -l swiftCore
+LDFLAGS ?= -Wl,-PIC,-ldl,-rpath,/usr/lib/swift/linux,-lswiftCore,-L/usr/lib/swift/linux
 endif
-
 
 EXECUTABLE ?= skit
 OTHER_CFLAGS ?= -g

--- a/filesystem.c
+++ b/filesystem.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+char *copy_file_contents(char *path);
+int file_readable(char *path);
+
+int file_readable(char *path) {
+  return access(path, R_OK) == 0;
+}
+
+char *copy_file_contents(char *path) {
+  FILE *fp = fopen(path, "r");
+  if (!fp) {
+    fclose(fp);
+    fprintf(stderr, "Failed to open file at '%s'\n", path);
+    exit(1);
+  }
+
+  fseek(fp, 0, SEEK_END);
+  long size = ftell(fp);
+  rewind(fp);
+  char *buffer = malloc((unsigned long)size + 1);
+  if (!buffer) {
+    fclose(fp);
+
+    fprintf(stderr, "Failed to allocate memory for reading '%s'\n", path);
+    exit(1);
+  }
+
+  if (!fread(buffer, (size_t)size, 1, fp)) {
+    fclose(fp);
+    free(buffer);
+
+    fprintf(stderr, "Failed to read file '%s'\n", path);
+    exit(1);
+  }
+
+  fclose(fp);
+  buffer[size] = '\0';
+  return buffer;
+}

--- a/filesystem.h
+++ b/filesystem.h
@@ -1,0 +1,2 @@
+char *copy_file_contents(char *path);
+int file_readable(char *path);

--- a/library.c
+++ b/library.c
@@ -1,0 +1,132 @@
+#include "library.h"
+#include "filesystem.h"
+#include "sourcekitd/sourcekitd.h"
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ENV_VAR "SOURCEKIT_BINARY_PATH"
+
+// Bind a given symbol from a dlopen'd binary to skit_$symbol
+// and then check for errors
+#define BIND(symbol)                                                           \
+  *(void **)(&skit_##symbol) = dlsym(handle, #symbol);                         \
+  check_dlerror();
+
+char *copy_xcode_select_sourcekit_path(void);
+char *sourcekit_binary_path(void);
+void check_dlerror(void);
+void load_sourcekit_symbols(void);
+
+bool (*skit_sourcekitd_response_is_error)(sourcekitd_response_t obj);
+char *(*skit_sourcekitd_variant_json_description_copy)(
+    sourcekitd_variant_t obj);
+sourcekitd_error_t (*skit_sourcekitd_response_error_get_kind)(
+    sourcekitd_response_t err);
+sourcekitd_object_t (*skit_sourcekitd_request_create_from_yaml)(
+    const char *yaml, char **error);
+sourcekitd_response_t (*skit_sourcekitd_send_request_sync)(
+    sourcekitd_object_t req);
+sourcekitd_variant_t (*skit_sourcekitd_response_get_value)(
+    sourcekitd_response_t resp);
+void (*skit_sourcekitd_initialize)(void);
+void (*skit_sourcekitd_response_dispose)(sourcekitd_response_t obj);
+void (*skit_sourcekitd_shutdown)(void);
+
+void check_dlerror() {
+  char *error = dlerror();
+  if (error) {
+    fprintf(stderr, "%s\n", error);
+    exit(EXIT_FAILURE);
+  }
+}
+
+char *sourcekit_binary_path() {
+#ifdef __APPLE__
+  char *options[3] = {
+      getenv(ENV_VAR),
+      "/Applications/Xcode.app/Contents/Developer/Toolchains/"
+      "XcodeDefault.xctoolchain/usr/lib/sourcekitd.framework/sourcekitd",
+      "/Applications/Xcode-Beta.app/Contents/Developer/Toolchains/"
+      "XcodeDefault.xctoolchain/usr/lib/sourcekitd.framework/sourcekitd",
+  };
+#else
+  char *options[2] = {
+      getenv(ENV_VAR), "/usr/lib/libsourcekitdInProc.so",
+  };
+#endif
+
+  int count = sizeof(options) / sizeof(char *);
+  for (int i = 0; i < count; i++) {
+    char *path = options[i];
+    if (path && file_readable(path)) {
+      return path;
+    }
+  }
+
+  return NULL;
+}
+
+char *copy_xcode_select_sourcekit_path() {
+  FILE *fp = popen("xcode-select -p", "r");
+  if (!fp) {
+    return NULL;
+  }
+
+  char *path = malloc(200);
+  fgets(path, 200, fp);
+  if (ferror(fp)) {
+    return NULL;
+  }
+
+  strtok(path, "\n");
+  strcat(path, "/Toolchains/XcodeDefault.xctoolchain/usr/lib/"
+               "sourcekitd.framework/sourcekitd");
+
+  return path;
+}
+
+void load_sourcekit_symbols() {
+  void *handle;
+  char *xcode_select_path = NULL;
+#ifdef __APPLE__
+  if (getenv(ENV_VAR) == NULL) {
+    xcode_select_path = copy_xcode_select_sourcekit_path();
+  }
+#endif
+
+  if (xcode_select_path) {
+    handle = dlopen(xcode_select_path, RTLD_LAZY);
+    free(xcode_select_path);
+  } else {
+    char *path = sourcekit_binary_path();
+    if (!path) {
+      fprintf(stderr,
+              "Couldn't find readable sourcekitd binary path. Set the "
+              "'%s' to override this.\n",
+              ENV_VAR);
+      exit(EXIT_FAILURE);
+    }
+
+    handle = dlopen(path, RTLD_LAZY);
+  }
+
+  if (!handle) {
+    fprintf(stderr, "Failed to open sourcekit framework '%s'\n", dlerror());
+    exit(EXIT_FAILURE);
+  }
+
+  dlerror();
+
+  BIND(sourcekitd_initialize);
+  BIND(sourcekitd_request_create_from_yaml);
+  BIND(sourcekitd_response_dispose);
+  BIND(sourcekitd_response_error_get_kind);
+  BIND(sourcekitd_response_get_value);
+  BIND(sourcekitd_response_is_error);
+  BIND(sourcekitd_send_request_sync);
+  BIND(sourcekitd_shutdown);
+  BIND(sourcekitd_variant_json_description_copy);
+}

--- a/library.h
+++ b/library.h
@@ -1,0 +1,18 @@
+#include "sourcekitd/sourcekitd.h"
+
+void load_sourcekit_symbols(void);
+
+extern bool (*skit_sourcekitd_response_is_error)(sourcekitd_response_t obj);
+extern char *(*skit_sourcekitd_variant_json_description_copy)(
+    sourcekitd_variant_t obj);
+extern sourcekitd_error_t (*skit_sourcekitd_response_error_get_kind)(
+    sourcekitd_response_t err);
+extern sourcekitd_object_t (*skit_sourcekitd_request_create_from_yaml)(
+    const char *yaml, char **error);
+extern sourcekitd_response_t (*skit_sourcekitd_send_request_sync)(
+    sourcekitd_object_t req);
+extern sourcekitd_variant_t (*skit_sourcekitd_response_get_value)(
+    sourcekitd_response_t resp);
+extern void (*skit_sourcekitd_initialize)(void);
+extern void (*skit_sourcekitd_response_dispose)(sourcekitd_response_t obj);
+extern void (*skit_sourcekitd_shutdown)(void);

--- a/main.c
+++ b/main.c
@@ -1,16 +1,16 @@
-#include <sourcekitd/sourcekitd.h>
+#include "filesystem.h"
+#include "library.h"
+#include "sourcekitd/sourcekitd.h"
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
-char *copy_file_contents(char *path);
 char *error_from_response(sourcekitd_response_t resp);
-int file_readable(char *path);
 int perform_sourcekit_request_from_yamlfile(char *filepath);
 
 char *error_from_response(sourcekitd_response_t resp) {
-  switch (sourcekitd_response_error_get_kind(resp)) {
+  switch (skit_sourcekitd_response_error_get_kind(resp)) {
     case SOURCEKITD_ERROR_CONNECTION_INTERRUPTED:
       return "connection interrupted";
     case SOURCEKITD_ERROR_REQUEST_INVALID:
@@ -22,47 +22,11 @@ char *error_from_response(sourcekitd_response_t resp) {
   }
 }
 
-int file_readable(char *path) {
-  return access(path, R_OK) == 0;
-}
-
-char *copy_file_contents(char *path) {
-  FILE *fp = fopen(path, "r");
-  if (!fp) {
-    fclose(fp);
-    fprintf(stderr, "Failed to open file at '%s'\n", path);
-    exit(1);
-  }
-
-  fseek(fp, 0, SEEK_END);
-  long size = ftell(fp);
-  rewind(fp);
-  char *buffer = malloc((unsigned long)size + 1);
-  if (!buffer) {
-    fclose(fp);
-
-    fprintf(stderr, "Failed to allocate memory for reading '%s'\n", path);
-    exit(1);
-  }
-
-  if (!fread(buffer, (size_t)size, 1, fp)) {
-    fclose(fp);
-    free(buffer);
-
-    fprintf(stderr, "Failed to read file '%s'\n", path);
-    exit(1);
-  }
-
-  fclose(fp);
-  buffer[size] = '\0';
-  return buffer;
-}
-
 int perform_sourcekit_request_from_yamlfile(char *filepath) {
   char *yaml = copy_file_contents(filepath);
   char *error = NULL;
   sourcekitd_object_t request =
-      sourcekitd_request_create_from_yaml(yaml, &error);
+      skit_sourcekitd_request_create_from_yaml(yaml, &error);
   free(yaml);
 
   if (!request) {
@@ -78,20 +42,20 @@ int perform_sourcekit_request_from_yamlfile(char *filepath) {
     return 1;
   }
 
-  sourcekitd_response_t response = sourcekitd_send_request_sync(request);
-  if (sourcekitd_response_is_error(response)) {
+  sourcekitd_response_t response = skit_sourcekitd_send_request_sync(request);
+  if (skit_sourcekitd_response_is_error(response)) {
     fprintf(stderr, "Got an error from sourcekitd: %s\n",
             error_from_response(response));
-    sourcekitd_response_dispose(response);
+    skit_sourcekitd_response_dispose(response);
 
     return 1;
   }
 
-  sourcekitd_variant_t value = sourcekitd_response_get_value(response);
-  char *json = sourcekitd_variant_json_description_copy(value);
+  sourcekitd_variant_t value = skit_sourcekitd_response_get_value(response);
+  char *json = skit_sourcekitd_variant_json_description_copy(value);
   printf("%s\n", json);
 
-  sourcekitd_response_dispose(response);
+  skit_sourcekitd_response_dispose(response);
   free(json);
 
   return 0;
@@ -114,9 +78,10 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  sourcekitd_initialize();
+  load_sourcekit_symbols();
+  skit_sourcekitd_initialize();
   int result = perform_sourcekit_request_from_yamlfile(filepath);
-  sourcekitd_shutdown();
+  skit_sourcekitd_shutdown();
 
   return result;
 }


### PR DESCRIPTION
This is a large change to move from statically linking the sourcekitd binary, to dynamically linking it. This means you no longer have to recompile skit when you change Xcode versions / paths.